### PR TITLE
Add a dependabot configuration for keeping actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
This PR adds a dependabot configuration to keep github actions up to date. It will run a check once a week to automatically create a PR to update an action if an action has a new version available.

To enable this, you'll need to go into the Security -> Code Security settings for the repository and click the Enable button next to Dependabot version updates. This should also activate the Dependabot on Actions runners button as well.

![A screenshot of the configuration options needed to enable dependabot.](https://private-user-images.githubusercontent.com/14017872/387834415-44ea0ef3-e147-47f5-afd3-a27f9276b3b0.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzMxODYyMDgsIm5iZiI6MTczMzE4NTkwOCwicGF0aCI6Ii8xNDAxNzg3Mi8zODc4MzQ0MTUtNDRlYTBlZjMtZTE0Ny00N2Y1LWFmZDMtYTI3ZjkyNzZiM2IwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDEyMDMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQxMjAzVDAwMzE0OFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWQ3NTU5NmUyZWFhYWUzOGYzMmUwMTMzNTViNTY1OTg5NjM3Yzc2MTc3MjVmMmRmMTk5NjQwMzc3MGM2ZTNiNDgmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.l3OV-Q3_bD-Vm1KOkIiCOvWm940xcherNxX1K74x8zU)