### PR TITLE
Add a release job to the build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,18 @@
-name: Build
+name: Build and publish to PyPI
 
 on:
   push:
     branches: main
   pull_request:
     branches: '*'
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        type: boolean
+        description: 'Test release: publish on test.pypi.org'
+        default: false
 
 jobs:
   build:
@@ -94,3 +102,36 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
+
+  publish:
+    name: Publish Python package on PyPI
+    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
+    needs: [build, test_isolated]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/jupyterlab-notify
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve extension artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: extension-artifacts
+          path: artifacts/
+
+      - name: List artifacts
+        run: ls -l artifacts/
+
+      - name: 🧪 Publish to PyPI Testing
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ inputs.test_pypi }}
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: artifacts
+
+      - name: 🎉 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        if: ${{ !inputs.test_pypi }}
+        with:
+          packages-dir: artifacts

--- a/README.md
+++ b/README.md
@@ -182,37 +182,11 @@ pip uninstall jupyterlab_notify
 
 ## Publishing
 
-Before starting, you'll need to have run: `pip install twine jupyter_packaging`
-
 1. Update the version in `package.json` and update the release date in `CHANGELOG.md`
-2. Commit the change in step 1, tag it, then push it
-
-```
-git commit -am <msg>
-git tag vX.Z.Y
-git push && git push --tags
-```
-
-3. Create the artifacts
-
-```
-rm -rf dist
-python setup.py sdist bdist_wheel
-```
-
-4. Test this against the test pypi. You can then install from here to test as well:
-
-```
-twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-# In a new venv
-pip install --index-url https://test.pypi.org/simple/ jupyterlab_notify
-```
-
-5. Upload this to pypi:
-
-```
-twine upload dist/*
-```
+2. Commit the change in step 1
+3. For test release, manually trigger the [`Build and publish to PyPI` workflow](https://github.com/deshaw/jupyterlab-notify/actions/workflows/build.yml) - you need to check the `Test release` checkbox
+4. Draft a new [GitHub release](https://github.com/deshaw/jupyterlab-notify/releases/new), creating an approriate version tag
+5. Publish the draft and verify that the `publish` job in the build workflow passed.
 
 ### Uninstall
 


### PR DESCRIPTION
This follows the same minimalistic approach used in pyflyby and [jupyterlab-execute-time](https://github.com/deshaw/jupyterlab-execute-time/pull/141).

This PR requires configuration of:
- [x] trusted publisher on PyPI
- [x] a `pypi` environment in the GitHub settings
